### PR TITLE
utilize python3.8 based s2i-custom-notebook as base image

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -7,7 +7,7 @@ check:
 build:
   build-stratergy: Source
   build-source-script: "image:///opt/app-root/builder"
-  base-image: quay.io/thoth-station/s2i-custom-notebook:latest
+  base-image: quay.io/thoth-station/s2i-custom-py38-notebook:latest
   registry: quay.io
   registry-org: aicoe
   registry-project: mailing-list-analysis-toolkit


### PR DESCRIPTION
## Related Issues and Dependencies

Related To: #10 #11 

## This Pull Request implements

utilize python3.8 based s2i-custom-notebook as the base image
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

As we are using python version 3.8 for the application, we should use an image with python 3.8 support while building a container image.  