### PR TITLE
set keyword analysis to only update the most recent months data

### DIFF
--- a/notebooks/stage/keyword_analysis.ipynb
+++ b/notebooks/stage/keyword_analysis.ipynb
@@ -24,6 +24,8 @@
     "import re\n",
     "from sklearn.feature_extraction.text import TfidfVectorizer\n",
     "from collections import Counter\n",
+    "import gc\n",
+    "\n",
     "\n",
     "from pathlib import Path\n",
     "\n",
@@ -43,106 +45,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "BASE_PATH = os.getenv(\"LOCAL_DATA_PATH\", \"../../data/\")"
+    "BASE_PATH = os.getenv(\"LOCAL_DATA_PATH\", \"../../data\")\n",
+    "\n",
+    "LAST_MONTH_DATE = datetime.datetime.now().replace(day=1) - datetime.timedelta(\n",
+    "    days=1\n",
+    ")\n",
+    "year = LAST_MONTH_DATE.year\n",
+    "month = LAST_MONTH_DATE.month"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Message-ID</th>\n",
-       "      <th>Date</th>\n",
-       "      <th>Body</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>&lt;1519862707.18745.0@posteo.de&gt;</td>\n",
-       "      <td>Wed, 28 Feb 2018 18:05:07 -0600</td>\n",
-       "      <td>['\\nI have an update here:\\n\\nhttps://bodhi.fe...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>&lt;b88b4d3b-b8f7-2ea6-ec41-ab572b831717@dustymab...</td>\n",
-       "      <td>Wed, 28 Feb 2018 19:43:15 -0500</td>\n",
-       "      <td>[\"-----BEGIN PGP SIGNED MESSAGE-----\\nHash: SH...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>&lt;45117c81-43ff-656d-85c3-3cf003bd0d14@fedorapr...</td>\n",
-       "      <td>Wed, 28 Feb 2018 20:49:25 -0500</td>\n",
-       "      <td>['On 02/28/2018 07:05 PM, mcatanzaro(a)gnome.o...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>&lt;CAA55FSN-R4oV0os0LihZQTp8aa0NkR9jQPh44subK2+9...</td>\n",
-       "      <td>Wed, 28 Feb 2018 21:11:19 -0500</td>\n",
-       "      <td>['On 28 February 2018 at 10:03, Nicolas Mailho...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>&lt;p77nrn$t3b$1@blaine.gmane.org&gt;</td>\n",
-       "      <td>Thu, 01 Mar 2018 03:19:34 +0100</td>\n",
-       "      <td>['Fabio Valentini wrote:\\n&gt; AFAICT, those \"bro...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                          Message-ID  \\\n",
-       "0                     <1519862707.18745.0@posteo.de>   \n",
-       "1  <b88b4d3b-b8f7-2ea6-ec41-ab572b831717@dustymab...   \n",
-       "2  <45117c81-43ff-656d-85c3-3cf003bd0d14@fedorapr...   \n",
-       "3  <CAA55FSN-R4oV0os0LihZQTp8aa0NkR9jQPh44subK2+9...   \n",
-       "4                    <p77nrn$t3b$1@blaine.gmane.org>   \n",
-       "\n",
-       "                              Date  \\\n",
-       "0  Wed, 28 Feb 2018 18:05:07 -0600   \n",
-       "1  Wed, 28 Feb 2018 19:43:15 -0500   \n",
-       "2  Wed, 28 Feb 2018 20:49:25 -0500   \n",
-       "3  Wed, 28 Feb 2018 21:11:19 -0500   \n",
-       "4  Thu, 01 Mar 2018 03:19:34 +0100   \n",
-       "\n",
-       "                                                Body  \n",
-       "0  ['\\nI have an update here:\\n\\nhttps://bodhi.fe...  \n",
-       "1  [\"-----BEGIN PGP SIGNED MESSAGE-----\\nHash: SH...  \n",
-       "2  ['On 02/28/2018 07:05 PM, mcatanzaro(a)gnome.o...  \n",
-       "3  ['On 28 February 2018 at 10:03, Nicolas Mailho...  \n",
-       "4  ['Fabio Valentini wrote:\\n> AFAICT, those \"bro...  "
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "df = utils.load_dataset(f\"{BASE_PATH}/interim/text/\")\n",
-    "df.head()"
+    "if os.getenv(\"RUN_IN_AUTOMATION\"):\n",
+    "    df = pd.read_csv(\n",
+    "        f\"{BASE_PATH}/interim/text/fedora-devel-{year}-{month}.mbox.csv\"\n",
+    "    )\n",
+    "    df.head()\n",
+    "\n",
+    "else:\n",
+    "    df = utils.load_dataset(f\"{BASE_PATH}/interim/text/\")\n",
+    "    df.head()"
    ]
   },
   {
@@ -678,11 +604,21 @@
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(440, 37733)\n"
+     ]
+    }
+   ],
    "source": [
-    "corpus = clean[clean.Chunk == datetime.date(2020, 11, 1)].Body\n",
-    "vectorizer = TfidfVectorizer()\n",
-    "X = vectorizer.fit_transform(corpus)"
+    "if not os.getenv(\"RUN_IN_AUTOMATION\"):\n",
+    "    corpus = clean[clean.Chunk == datetime.date(2020, 11, 1)].Body\n",
+    "    vectorizer = TfidfVectorizer()\n",
+    "    X = vectorizer.fit_transform(corpus)\n",
+    "    print(X.shape)"
    ]
   },
   {
@@ -691,97 +627,30 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "(440, 37733)"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['cloudbaseqcow2qcow2', 'ttest', 'aarch64', 'x8664', 'uefiurl', 'fedoracloud3320201031', 'soft', '712248', '712249', '712250']\n",
+      "\n",
+      "[No missing expected images.Soft failed openQA tests: 1/7 (x8664), 1/7 (aarch64)(Tests completed, but using a workaround for a known bug)Old soft failures (same test soft failed in FedoraCloud3320201031.0):ID: 712253\\tTest: x8664 CloudBaseqcow2qcow2 cloudautocloudURL: 712261\\tTest: aarch64 CloudBaseqcow2qcow2 cloudautocloud(a)uefiURL: openQA tests: 6/7 (x8664), 6/7 (aarch64)New passes (same test not passed in FedoraCloud3320201031.0):ID: 712248\\tTest: x8664 CloudBaseqcow2qcow2 baserebootunmountURL: 712249\\tTest: x8664 CloudBaseqcow2qcow2 basesystemloggingURL: 712250\\tTest: x8664 CloudBaseqcow2qcow2 baseupdatecliURL: 712251\\tTest: x8664 CloudBaseqcow2qcow2 baseservicemanipulationURL: 712252\\tTest: x8664 CloudBaseqcow2qcow2 baseservicesstartURL: 712254\\tTest: x8664 CloudBaseqcow2qcow2 baseselinuxURL: 712255\\tTest: aarch64 CloudBaseqcow2qcow2 basesystemlogging(a)uefiURL: 712256\\tTest: aarch64 CloudBaseqcow2qcow2 baserebootunmount(a)uefiURL: 712257\\tTest: aarch64 CloudBaseqcow2qcow2 baseservicesstart(a)uefiURL: 712258\\tTest: aarch64 CloudBaseqcow2qcow2 baseupdatecli(a)uefiURL: 712259\\tTest: aarch64 CloudBaseqcow2qcow2 baseservicemanipulation(a)uefiURL: 712260\\tTest: aarch64 CloudBaseqcow2qcow2 baseselinux(a)uefiURL: Mail generated by checkcompose:\n"
+     ]
     }
    ],
    "source": [
-    "X.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['cloudbaseqcow2qcow2',\n",
-       " 'ttest',\n",
-       " 'aarch64',\n",
-       " 'x8664',\n",
-       " 'uefiurl',\n",
-       " 'fedoracloud3320201031',\n",
-       " 'soft',\n",
-       " '712248',\n",
-       " '712249',\n",
-       " '712250']"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "feature_array = np.array(vectorizer.get_feature_names())\n",
+    "if not os.getenv(\"RUN_IN_AUTOMATION\"):\n",
+    "    feature_array = np.array(vectorizer.get_feature_names())\n",
     "\n",
-    "Document = []\n",
-    "for i, j in enumerate(X[0].toarray()[0]):\n",
-    "    if j > 0:\n",
-    "        Document.append((i, j))\n",
+    "    Document = []\n",
+    "    for i, j in enumerate(X[0].toarray()[0]):\n",
+    "        if j > 0:\n",
+    "            Document.append((i, j))\n",
     "\n",
-    "top_10 = sorted(Document, key=lambda x: x[1], reverse=True)[0:10]\n",
-    "top_10_keys = [x[0] for x in top_10]\n",
-    "[feature_array[i] for i in top_10_keys]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "13427    [No missing expected images.Soft failed openQA...\n",
-       "Name: Body, dtype: object"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "corpus[0:1]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'[No missing expected images.Soft failed openQA tests: 1/7 (x8664), 1/7 (aarch64)(Tests completed, but using a workaround for a known bug)Old soft failures (same test soft failed in FedoraCloud3320201031.0):ID: 712253\\\\tTest: x8664 CloudBaseqcow2qcow2 cloudautocloudURL: 712261\\\\tTest: aarch64 CloudBaseqcow2qcow2 cloudautocloud(a)uefiURL: openQA tests: 6/7 (x8664), 6/7 (aarch64)New passes (same test not passed in FedoraCloud3320201031.0):ID: 712248\\\\tTest: x8664 CloudBaseqcow2qcow2 baserebootunmountURL: 712249\\\\tTest: x8664 CloudBaseqcow2qcow2 basesystemloggingURL: 712250\\\\tTest: x8664 CloudBaseqcow2qcow2 baseupdatecliURL: 712251\\\\tTest: x8664 CloudBaseqcow2qcow2 baseservicemanipulationURL: 712252\\\\tTest: x8664 CloudBaseqcow2qcow2 baseservicesstartURL: 712254\\\\tTest: x8664 CloudBaseqcow2qcow2 baseselinuxURL: 712255\\\\tTest: aarch64 CloudBaseqcow2qcow2 basesystemlogging(a)uefiURL: 712256\\\\tTest: aarch64 CloudBaseqcow2qcow2 baserebootunmount(a)uefiURL: 712257\\\\tTest: aarch64 CloudBaseqcow2qcow2 baseservicesstart(a)uefiURL: 712258\\\\tTest: aarch64 CloudBaseqcow2qcow2 baseupdatecli(a)uefiURL: 712259\\\\tTest: aarch64 CloudBaseqcow2qcow2 baseservicemanipulation(a)uefiURL: 712260\\\\tTest: aarch64 CloudBaseqcow2qcow2 baseselinux(a)uefiURL: Mail generated by checkcompose:'"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "corpus[corpus[0:1].index[0]]"
+    "    top_10 = sorted(Document, key=lambda x: x[1], reverse=True)[0:10]\n",
+    "    top_10_keys = [x[0] for x in top_10]\n",
+    "    print([feature_array[i] for i in top_10_keys], end=\"\\n\\n\")\n",
+    "    print(corpus[corpus[0:1].index[0]])\n",
+    "    del feature_array\n",
+    "    gc.collect()"
    ]
   },
   {
@@ -795,14 +664,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Run full analysis entire dataset \n",
+    "### Run full analysis on entire dataset \n",
     "\n",
     "Now that we are confident our approach works, we will break it up into manageable functions and apply it to each months dataset. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -833,13 +702,25 @@
     "    keywords = Counter(keywords).most_common(10)\n",
     "    keywords = pd.DataFrame(keywords, columns=[\"word\", \"count\"])\n",
     "    keywords[\"month\"] = chunk\n",
+    "    del feature_array\n",
+    "    gc.collect()\n",
     "\n",
     "    return keywords"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_base_path = Path(f\"{BASE_PATH}/processed/keywords/\")\n",
+    "dataset_base_path.mkdir(parents=True, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -888,39 +769,23 @@
     "# For each document collect the top 10 words, then sum the top 10 for each month.\n",
     "\n",
     "months = clean.Chunk.unique()\n",
-    "monthly_keywords = pd.DataFrame([], columns=[\"word\", \"count\", \"month\"])\n",
+    "new_files = []\n",
     "\n",
     "for month in months:\n",
     "    corpus = clean[clean.Chunk == month].Body\n",
-    "    monthly_keywords = monthly_keywords.append(\n",
-    "        get_monthly_keywords(corpus, month), ignore_index=True\n",
+    "    monthly_keywords = get_monthly_keywords(corpus, month)\n",
+    "    monthly_keywords = monthly_keywords.reset_index().set_index(\"word\")\n",
+    "    monthly_keywords = monthly_keywords.drop(\"index\", axis=1)\n",
+    "    monthly_keywords.to_csv(\n",
+    "        f\"{BASE_PATH}/processed/keywords/keywords-{month}.csv\", header=False\n",
     "    )\n",
-    "    print(month)\n",
-    "\n",
-    "monthly_keywords = pd.DataFrame(monthly_keywords)"
+    "    new_files.append(f\"{BASE_PATH}/processed/keywords/keywords-{month}.csv\")\n",
+    "    print(month)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "monthly_keywords = monthly_keywords.reset_index().set_index(\"word\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "monthly_keywords = monthly_keywords.drop(\"index\", axis=1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -955,34 +820,29 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>fc28</th>\n",
-       "      <td>32</td>\n",
-       "      <td>2018-01-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>test</th>\n",
-       "      <td>31</td>\n",
-       "      <td>2018-01-01</td>\n",
+       "      <th>aarch64</th>\n",
+       "      <td>116</td>\n",
+       "      <td>2020-11-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>x8664</th>\n",
-       "      <td>27</td>\n",
-       "      <td>2018-01-01</td>\n",
+       "      <td>115</td>\n",
+       "      <td>2020-11-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>pc9kaxy</th>\n",
-       "      <td>26</td>\n",
-       "      <td>2018-01-01</td>\n",
+       "      <th>ttest</th>\n",
+       "      <td>94</td>\n",
+       "      <td>2020-11-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>change</th>\n",
-       "      <td>26</td>\n",
-       "      <td>2018-01-01</td>\n",
+       "      <th>tests</th>\n",
+       "      <td>77</td>\n",
+       "      <td>2020-11-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
+       "      <th>failed</th>\n",
+       "      <td>64</td>\n",
+       "      <td>2020-11-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>cloudbaseqcow2qcow2</th>\n",
@@ -1011,28 +871,24 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>350 rows × 2 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "                    count       month\n",
-       "word                                 \n",
-       "fc28                   32  2018-01-01\n",
-       "test                   31  2018-01-01\n",
-       "x8664                  27  2018-01-01\n",
-       "pc9kaxy                26  2018-01-01\n",
-       "change                 26  2018-01-01\n",
-       "...                   ...         ...\n",
-       "cloudbaseqcow2qcow2    56  2020-11-01\n",
-       "soft                   55  2020-11-01\n",
-       "test                   39  2020-11-01\n",
-       "uefiurl                36  2020-11-01\n",
-       "package                31  2020-11-01\n",
-       "\n",
-       "[350 rows x 2 columns]"
+       "                     count       month\n",
+       "word                                  \n",
+       "aarch64                116  2020-11-01\n",
+       "x8664                  115  2020-11-01\n",
+       "ttest                   94  2020-11-01\n",
+       "tests                   77  2020-11-01\n",
+       "failed                  64  2020-11-01\n",
+       "cloudbaseqcow2qcow2     56  2020-11-01\n",
+       "soft                    55  2020-11-01\n",
+       "test                    39  2020-11-01\n",
+       "uefiurl                 36  2020-11-01\n",
+       "package                 31  2020-11-01"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1050,40 +906,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "new_files = ((monthly_keywords, f\"{BASE_PATH}/processed/keywords.csv\"),)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "Path(f\"{BASE_PATH}/processed\").mkdir(parents=True, exist_ok=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "monthly_keywords.to_csv(new_files[0][1], header=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
     "if os.getenv(\"RUN_IN_AUTOMATION\"):\n",
     "    utils.upload_files(\n",
-    "        (f, f\"processed/{Path(f).stem}/keywords.csv\") for _, f in new_files\n",
+    "        (f, f\"processed/keywords/{Path(f).stem}.csv\") for f in new_files\n",
     "    )"
    ]
   }


### PR DESCRIPTION
## Related Issues and Dependencies

None
## This introduces a breaking change

- [ ] Yes
- [X] No

## This Pull Request implements

In an effort to lower the memory footprint of "keyword_analysis.ipynb" this PR implements a "RUN_IN_AUTOMATION" statement that limits the analysis to only the most recent month of data instead of processing the entire dataset. This PR also implements a garbage collection step after each TF-IDF model training and keyword identification to free up memory in the cases where we are running this for multiple months out of automation.  

Also, instead of maintaining a single *csv in ceph to make our Hive tables, this PR will add new {year}-{month}.csv's for each month. I have already back-filled the Ceph bucket with data for the last 2 years and the Superset Dashboard appears to successfully handle the slight change in data storage. 

**note:** Although the vast majority of months seems to take only a few GB of memory to process, reviewing the output while back-filling the data, it seems as though there are a couple outlier that can take up to 20GB which can crash a pod in automation. In a future PR, I will look deeper into these edge cases and see if they can be mitigated by either additional data cleaning or finding a more memory efficient way to process the data.      

## Description

