### PR TITLE
fix: Ceph endpoint and image working dir in the Argo workflow

### DIFF
--- a/manifests/wftmpl.yaml
+++ b/manifests/wftmpl.yaml
@@ -74,7 +74,7 @@ spec:
             archive:
               none: {}
             s3:
-              endpoint: rook-ceph-rgw-ocs-storagecluster-cephobjectstore.openshift-storage.svc.cluster.local
+              endpoint: https://rook-ceph-rgw-ocs-storagecluster-cephobjectstore.openshift-storage.svc.cluster.local
               bucket: mailing-list-analysis-toolkit
               key: "production_data/rendered_notebooks/{{inputs.parameters.notebook}}"
               accessKeySecret:
@@ -90,7 +90,7 @@ spec:
         args:
           - "notebooks/{{inputs.parameters.notebook}}" # input
           - "/mnt/data/notebooks/{{inputs.parameters.notebook}}" # output
-        workingDir: /opt/app-root/src
+        workingDir: /opt/app-root/backup
         volumeMounts:
           - name: local-data-storage
             mountPath: /mnt/data
@@ -100,7 +100,7 @@ spec:
           - name: RUN_IN_AUTOMATION
             value: "true"
           - name: S3_ENDPOINT_URL
-            value: rook-ceph-rgw-ocs-storagecluster-cephobjectstore.openshift-storage.svc.cluster.local
+            value: https://rook-ceph-rgw-ocs-storagecluster-cephobjectstore.openshift-storage.svc.cluster.local
           - name: S3_PROJECT_KEY
             value: ""
           - name: S3_BUCKET


### PR DESCRIPTION
Signed-off-by: Tomas Coufal <tcoufal@redhat.com>

## Related Issues and Dependencies

#33 

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

- New image has to be executed from a different path, no idea why.
- The ceph endpoint needs `https://` prefix

